### PR TITLE
possibility to use the predefined initial water level raster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
         run: make test
       - name: create packages
         run: bin/python setup.py sdist bdist_wheel
-      - name: coverage report
-        run: bin/coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      # - name: coverage report
+      #   run: bin/coveralls
+      #   env:
+      #     COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       - name: Publish package
         if: startsWith(github.event.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ The expected information in run_info.xml is::
 	  <string key="fews_pre_processing" value="True"/>
 	  <string key="lizard_results_scenario_name" value="Testsimulatie"/>
 	  <string key="lizard_results_scenario_uuid" value=""/>
+	  <string key="initial_waterlevel" value=""/>
       </properties>
   </Run>
   
@@ -83,6 +84,8 @@ A cold state is supplied in a similar way with the name:
 
 
 **fews_pre_processing:** can be ``True`` or ``False``. Must be True if the results are needed in fews: additional pre_processing of the results is needed.
+
+**initial_waterlevel:** can be ``min``, ``max``, or ``mean``. When specified the initial waterlevel raster is taken into account. If left empty no initial waterlevel is used in the simulation. 
 
 
 Several input files are needed, they should be in the ``input`` directory

--- a/fews_3di/simulation.py
+++ b/fews_3di/simulation.py
@@ -354,14 +354,17 @@ class ThreediSimulation:
         logger.info("Saved state will be stored: %s", saved_state.url)
         return saved_state.id
 
-
-
-def _add_initial_waterlevel_raster(self):
+    def _add_initial_waterlevel_raster(self):
         """Upload initial waterlevel raster and wait for it to be processed."""
         logger.info("Uploading initial waterlevel raster...")
-        ini_wl_api_call = self.simulations_api.simulations_initial1d_water_level_predfined_create(
-                simulation_pk=self.simulation_id, data={}, aggregation_method=self.settings.initial_waterlevel))
-       
+        ini_wl_api_call = (
+            self.simulations_api.simulations_initial1d_water_level_predfined_create(
+                simulation_pk=self.simulation_id,
+                data={},
+                aggregation_method=self.settings.initial_waterlevel,
+            )
+        )
+
         logger.info("Added initial waterlevel raster to %s", ini_wl_api_call.url)
 
     def _add_netcdf_rain(self, rain_raster_netcdf: Path):

--- a/fews_3di/simulation.py
+++ b/fews_3di/simulation.py
@@ -354,6 +354,16 @@ class ThreediSimulation:
         logger.info("Saved state will be stored: %s", saved_state.url)
         return saved_state.id
 
+
+
+def _add_initial_waterlevel_raster(self):
+        """Upload initial waterlevel raster and wait for it to be processed."""
+        logger.info("Uploading initial waterlevel raster...")
+        ini_wl_api_call = self.simulations_api.simulations_initial1d_water_level_predfined_create(
+                simulation_pk=self.simulation_id, data={}, aggregation_method=self.settings.initial_waterlevel))
+       
+        logger.info("Added initial waterlevel raster to %s", ini_wl_api_call.url)
+
     def _add_netcdf_rain(self, rain_raster_netcdf: Path):
         """Upload rain raster netcdf file and wait for it to be processed."""
         logger.info("Uploading rain rasters...")

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -51,7 +51,7 @@ class Settings:
     rain_type: str
     rain_input: str
     fews_pre_processing: bool
-	initial_waterlevel: str
+    initial_waterlevel: str
 
     def __init__(self, settings_file: Path):
         """Read settings from the xml settings file."""
@@ -80,7 +80,7 @@ class Settings:
             "lizard_results_scenario_uuid",
             "rain_type",
             "rain_input",
-			"initial_waterlevel",
+            "initial_waterlevel",
         ]
         for property_name in required_properties:
             self._read_property(property_name)

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -51,6 +51,7 @@ class Settings:
     rain_type: str
     rain_input: str
     fews_pre_processing: bool
+	initial_waterlevel: str
 
     def __init__(self, settings_file: Path):
         """Read settings from the xml settings file."""
@@ -79,6 +80,7 @@ class Settings:
             "lizard_results_scenario_uuid",
             "rain_type",
             "rain_input",
+			"initial_waterlevel",
         ]
         for property_name in required_properties:
             self._read_property(property_name)


### PR DESCRIPTION
it is an optional setting. If you want to make use of the predefined initial water level raster (defined in its sqlite), you can choose the aggregation methods min, mean and max.

@reinout can you check my adjustments?