### PR TITLE
More windows-friendly way of moving

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,8 @@ Changelog of fews-3di
 2.2 (unreleased)
 ----------------
 
-- Moving from temp to the actual file in a more windows-friendly way. (The old
-  way of moving between a temp dir on ``c:`` and a target dir on ``d:`` wasn't
-  allowed).
+- Moving from temp to the actual file in a more windows-friendly way. (Moving
+  between a temp dir on ``c:`` and a target dir on ``d:`` isn't allowed).
 
 
 2.1 (2022-07-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog of fews-3di
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Moving from temp to the actual file in a more windows-friendly way. (The old
+  way of moving between a temp dir on ``c:`` and a target dir on ``d:`` wasn't
+  allowed).
 
 
 2.1 (2022-07-28)
@@ -13,7 +15,7 @@ Changelog of fews-3di
 
 - Simulation templates are used to create a simulation to adjust to the new 3Di version.
 - Added a seperate folder for the states of the staging (states_staging)
-  
+
 
 
 2.0 (2022-06-21)

--- a/fews_3di/simulation.py
+++ b/fews_3di/simulation.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from threedi_api_client import openapi
 from threedi_api_client import ThreediApi
 from threedigrid.admin.gridresultadmin import GridH5ResultAdmin
+from typing import Dict
 from typing import List
 from typing import Tuple
 
@@ -216,7 +217,7 @@ class ThreediSimulation:
         logger.info("Simulation %s has been created", simulation.url)
         return simulation.id, simulation.url
 
-    def _add_laterals(self, laterals):
+    def _add_laterals(self, laterals: Dict[str, List[OffsetAndValue]]):
         """Upload lateral timeseries and wait for them to be processed."""
         still_to_process: List[int] = []
         logger.info("Uploading %s lateral timeseries...", len(laterals))

--- a/fews_3di/simulation.py
+++ b/fews_3di/simulation.py
@@ -12,6 +12,7 @@ import logging
 import netCDF4
 import pandas as pd
 import requests
+import shutil
 import socket
 import time
 import warnings
@@ -622,7 +623,7 @@ class ThreediSimulation:
             open_water_input_file, self.settings
         )
         # converted_netcdf is a temp file, so move it to the correct spot.
-        converted_netcdf.replace(open_water_output_file)
+        shutil.move(converted_netcdf, open_water_input_file)
         logger.debug("Started open water output file %s", open_water_output_file)
         dset = netCDF4.Dataset(open_water_output_file, "a")
         s1 = (


### PR DESCRIPTION
See https://stackoverflow.com/a/21116654/27401
`shutil.move()` is supposed to be more friendly to windows.