### PR TITLE
optional boundary file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,14 +5,14 @@ Changelog of fews-3di
 3.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added option to add lizard timeseries as a boundary condition.
 
 
 3.1 (2023-08-14)
 ----------------
 
-- Option to set multiplier by using rain radar as forcing. The multiplier is 
-  set by the user in the settings file. 
+- Option to set multiplier by using rain radar as forcing. The multiplier is
+  set by the user in the settings file.
 
 
 3.0.1 (2023-03-10)

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,8 @@ The expected information in run_info.xml is::
           <string key="lizard_results_scenario_uuid" value=""/>
           <string key="initial_waterlevel" value=""/>
           <string key="api_host" value=""/>
+          <string key="use_lizard_timeseries_as_boundary" value=""/>
+          <string key="boundary_file" value="boundary_file.json"/>
       </properties>
   </Run>
 
@@ -117,6 +119,15 @@ should be saved. If left empty the end of the simulation is used.
 
 **api_host:** (optional) api_host address can be added here. If not provided
  the default api_host address ("https://api.3di.live/v3.0") will be used.
+ 
+**use_lizard_timeseries_as_boundary:** (optional) can be ``True`` or ``False``.
+ Must be True if the boundary conditions of the simulation has to be updated by 
+ the boundary_file.json 
+
+**boundary_file:** (optional) the name of the boundary json file that will be 
+updated to the simulation if ``use_lizard_timeseries_as_boundary`` is ``True``.
+ No checks are done for the content of the file. 
+
 
 Several input files are needed, they should be in the ``input`` directory
 **relative** to the ``run_info.xml``:
@@ -128,6 +139,8 @@ Several input files are needed, they should be in the ``input`` directory
 - ``input/precipitation.nc``
 
 - ``input/evaporation.nc``
+
+- ``input/boundary_file.json``
 
 - ``input/ow.nc``
 

--- a/fews_3di/scripts.py
+++ b/fews_3di/scripts.py
@@ -1,5 +1,6 @@
 """Script to start 3Di simulations from FEWS.
 """
+
 # ^^^ This docstring is automatically used in the command line help text.
 from fews_3di import simulation
 from fews_3di import utils

--- a/fews_3di/simulation.py
+++ b/fews_3di/simulation.py
@@ -106,16 +106,6 @@ class ThreediSimulation:
         model_id = self._find_model()
         self.simulation_id, self.simulation_url = self._create_simulation(model_id)
 
-        if self.settings.use_lizard_timeseries_as_boundary:
-            boundary_json = (
-                self.settings.base_dir / "input" / self.settings.boundary_file
-            )
-            if boundary_json.exists():
-                # rain = utils.rain_csv_timeseries(rain_csv, self.settings)
-                self._add_boundary(self.settings.boundary_file)
-            else:
-                logger.info("No json boundary file found, skipping.")
-
         laterals_csv = self.settings.base_dir / "input" / "lateral.csv"
         if laterals_csv.exists():
             laterals = utils.lateral_timeseries(laterals_csv, self.settings)
@@ -178,6 +168,16 @@ class ThreediSimulation:
             self._process_basic_lizard_results()
         else:
             logger.info("Not processing basic results in Lizard")
+
+        if self.settings.use_lizard_timeseries_as_boundary:
+            boundary_json = (
+                self.settings.base_dir / "input" / self.settings.boundary_file
+            )
+            if boundary_json.exists():
+                # rain = utils.rain_csv_timeseries(rain_csv, self.settings)
+                self._add_boundary(self.settings.boundary_file)
+            else:
+                logger.info("No json boundary file found, skipping.")
 
         self._run_simulation()
         self._download_results()

--- a/fews_3di/tests/conftest.py
+++ b/fews_3di/tests/conftest.py
@@ -6,6 +6,7 @@ below) returns. In this case a settings object in a temp directory with the
 necessary sample data.
 
 """
+
 from fews_3di import utils
 from pathlib import Path
 

--- a/fews_3di/tests/test_scripts.py
+++ b/fews_3di/tests/test_scripts.py
@@ -1,4 +1,5 @@
 """Tests for script.py"""
+
 from fews_3di import scripts
 
 import mock

--- a/fews_3di/tests/test_utils.py
+++ b/fews_3di/tests/test_utils.py
@@ -3,6 +3,7 @@
 Note: the 'example_settings' pytest fixture is defined in conftest.py.
 
 """
+
 from fews_3di import utils
 from pathlib import Path
 

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -44,6 +44,7 @@ class Settings:
     # Instance variables with their types
     api_host: str
     api_token: str
+    boundary_file: str
     end: datetime.datetime
     fews_pre_processing: bool
     initial_waterlevel: str
@@ -60,6 +61,7 @@ class Settings:
     simulationname: str
     start: datetime.datetime
     use_last_available_state: bool
+    use_lizard_timeseries_as_boundary: bool
 
     def __init__(self, settings_file: Path):
         """Read settings from the xml settings file."""
@@ -96,6 +98,8 @@ class Settings:
             "initial_waterlevel",
             "save_state_time",
             "api_host",
+            "boundary_file",
+            "use_lizard_timeseries_as_boundary",
         ]
 
         for property_name in deprecated_properties:
@@ -144,6 +148,9 @@ class Settings:
             value = string_value.lower() == "true"
 
         elif property_name == "use_last_available_state":
+            value = string_value.lower() == "true"
+
+        elif property_name == "use_lizard_timeseries_as_boundary":
             value = string_value.lower() == "true"
 
         elif property_name == "saved_state_expiry_days":

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -109,7 +109,7 @@ class Settings:
             self._read_property(property_name)
 
         for property_name in optional_properties:
-            self._read_property(property_name, True)
+            self._read_property(property_name, optional=True)
 
         datetime_variables = ["start", "end"]
         for datetime_variable in datetime_variables:

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -221,9 +221,9 @@ def lateral_timeseries(
     rows = rows[2:]
 
     timeseries: Dict[str, List[OffsetAndValue]] = {}
-    previous_values: Dict[
-        str, float
-    ] = {}  # Values can be omitted if they stay the same.
+    previous_values: Dict[str, float] = (
+        {}
+    )  # Values can be omitted if they stay the same.
     for header in headers:
         timeseries[header] = []
 

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -66,9 +66,13 @@ class Settings:
     def __init__(self, settings_file: Path):
         """Read settings from the xml settings file."""
         self.settings_file = settings_file
-        setattr(self, "lizard_results_scenario_name", "")
-        setattr(self, "lizard_results_scenario_uuid", "")
-        setattr(self, "api_host", DEFAULT_API_HOST)
+        # First some defaults for optional properties
+        self.lizard_results_scenario_name = ""
+        self.lizard_results_scenario_uuid = ""
+        self.api_host = DEFAULT_API_HOST
+        self.use_lizard_timeseries_as_boundary = False
+        self.boundary_file = ""
+
         logger.info("Reading settings from %s...", self.settings_file)
         try:
             self._root = ET.fromstring(self.settings_file.read_text())


### PR DESCRIPTION
HEy Reinout,

I added two new setting options for reading and updating a boundary file. My changes has no check about the content of the bounhdary file.

That is something Eshter is doing in her script to prepare the boundary file.

Idea is when a simulation is created and the option to update boundary file is True, script should use the boundary.json file in the input folder to update the bouhndary condition of the simulation.

LEt me know if this is ok.

Cheers,

Boran