### PR TITLE
changes in the boundary file processing time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of fews-3di
 3.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Increased the file processing time for boundary files.
 
 
 3.4.3 (2024-02-28)

--- a/fews_3di/simulation.py
+++ b/fews_3di/simulation.py
@@ -22,7 +22,7 @@ CHUNK_SIZE = 1024 * 1024  # 1MB
 SAVED_STATE_ID_FILENAME = "3di-saved-state-id.txt"
 COLD_STATE_ID_FILENAME = "3di-cold-state-id.txt"
 SIMULATION_STATUS_CHECK_INTERVAL = 30
-UPLOAD_STATUS_CHECK_INTERVAL = 2
+UPLOAD_STATUS_CHECK_INTERVAL = 5
 USER_AGENT = "fews-3di (https://github.com/nens/fews-3di/)"
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Hey Reinout,

We use UPLOAD_STATUS_CHECK_INTERVAL in simulation.py for adding a file processing time. Martijn just told me that the 2 seconds we defined earlier is not enough for staging so I increased it to 5 seconds.

THats the only change... I added the change also to changes.

Can we relase this...

Cheers,

Boran