### PR TITLE
simulation template option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@ Changelog of fews-3di
 ===================================================
 
 
-3.6 (unreleased)
+3.6 (2024-07-15)
 ----------------
 
-- Nothing changed yet.
+- Added options to work with 3Di model templates.
 
 
 3.5 (2024-04-15)

--- a/README.rst
+++ b/README.rst
@@ -137,8 +137,8 @@ updated to the simulation if ``use_lizard_timeseries_as_boundary`` is ``True``.
 No checks are done for the content of the file.
 
 **simulation_template:** (optional) the name of the simulation template to be
-used for the simulation. If not provided defaults to ``default``, the 
-simulation template generated at model creation. 
+used for the simulation. If not provided defaults to ``default``, the
+simulation template generated at model creation.
 
 Several input files are needed, they should be in the ``input`` directory
 **relative** to the ``run_info.xml``:

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ The expected information in run_info.xml is::
           <string key="api_host" value=""/>
           <string key="use_lizard_timeseries_as_boundary" value=""/>
           <string key="boundary_file" value="boundary_file.json"/>
+          <string key="simulation_template" value="default"/>
       </properties>
   </Run>
 
@@ -135,6 +136,9 @@ the boundary_file.json
 updated to the simulation if ``use_lizard_timeseries_as_boundary`` is ``True``.
 No checks are done for the content of the file.
 
+**simulation_template:** (optional) the name of the simulation template to be
+used for the simulation. If not provided defaults to ``default``, the 
+simulation template generated at model creation. 
 
 Several input files are needed, they should be in the ``input`` directory
 **relative** to the ``run_info.xml``:

--- a/fews_3di/simulation.py
+++ b/fews_3di/simulation.py
@@ -208,10 +208,11 @@ class ThreediSimulation:
         """Return id and url of created simulation."""
         try:
             simulation_template = self.api.simulation_templates_list(
-                simulation__threedimodel__id=model_id
+                name=self.settings.simulation_template,
+                simulation__threedimodel__id=model_id,
             ).results[0]
         except IndexError:
-            msg = f"No simulation template for model id with {model_id}"
+            msg = f"No simulation template named {self.settings.simulation_template} for model with id {model_id}"
             raise MissingSimulationTemplateError(msg)
         data = {}
         data["name"] = self.settings.simulationname

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -56,6 +56,7 @@ class Settings:
     saved_state_expiry_days: int
     settings_file: Path
     simulationname: str
+    simulation_template: str
     start: datetime.datetime
     use_last_available_state: bool
     use_lizard_timeseries_as_boundary: bool
@@ -69,6 +70,7 @@ class Settings:
         self.api_host = DEFAULT_API_HOST
         self.use_lizard_timeseries_as_boundary = False
         self.boundary_file = ""
+        self.simulation_template = "default"
 
         logger.info("Reading settings from %s...", self.settings_file)
         try:
@@ -101,6 +103,7 @@ class Settings:
             "api_host",
             "boundary_file",
             "use_lizard_timeseries_as_boundary",
+            "simulation_template"
         ]
 
         for property_name in deprecated_properties:

--- a/fews_3di/utils.py
+++ b/fews_3di/utils.py
@@ -103,7 +103,7 @@ class Settings:
             "api_host",
             "boundary_file",
             "use_lizard_timeseries_as_boundary",
-            "simulation_template"
+            "simulation_template",
         ]
 
         for property_name in deprecated_properties:


### PR DESCRIPTION
Hoi Reinout,

Ik kwam een probleempje met deze library tegen, hij pakt altijd het eerste template uit de lijst vanuit de 3Di API. Dat is meestal geen probleem omdat er maar een template per model bestaat, maar soms dus wel. Met deze fix pakt hij standaard het default template en heb je de optie om een ander template op te geven in de xml. Zou jij dit kunnen controleren en verwerken?

Groet,
Martijn